### PR TITLE
Remove nil return value in chat function

### DIFF
--- a/functions/src/functionImplementations/openai-proxy.ts
+++ b/functions/src/functionImplementations/openai-proxy.ts
@@ -16,7 +16,6 @@ import type {
 import {retrieveRAGContext} from "../rag/retriever";
 import {serviceAccount} from "../utils/firebase";
 import {openAIAPIKey} from "../utils/genkit";
-import {z} from "genkit";
 
 type ChatBody =
   | ChatCompletionCreateParamsStreaming
@@ -106,7 +105,7 @@ export const chat = onCall(
       const ragEnabled = req.rawRequest.query.ragEnabled !== "false";
       console.log(`[RAG] RAG enabled: ${ragEnabled}`);
 
-      let studyId = "spineAI";
+      const studyId = "spineAI";
 
       // RAG: Retrieve context for the last user message
       let ragContext = "";

--- a/functions/src/functionImplementations/openai-proxy.ts
+++ b/functions/src/functionImplementations/openai-proxy.ts
@@ -106,14 +106,7 @@ export const chat = onCall(
       const ragEnabled = req.rawRequest.query.ragEnabled !== "false";
       console.log(`[RAG] RAG enabled: ${ragEnabled}`);
 
-      let studyId: string;
-      const defaultStudyId = "edu.stanford.LLMonFHIR.spineAI";
-      try {
-        studyId = z.string().optional().parse(req.rawRequest.query.studyId) ?? defaultStudyId;
-      } catch {
-        console.warn("[RAG]: Falling back to default studyId");
-        studyId = defaultStudyId;
-      }
+      let studyId = "spineAI";
 
       // RAG: Retrieve context for the last user message
       let ragContext = "";

--- a/functions/src/functionImplementations/openai-proxy.ts
+++ b/functions/src/functionImplementations/openai-proxy.ts
@@ -111,7 +111,7 @@ export const chat = onCall(
       let ragContext = "";
       try {
         const chatHistory = chatBody.messages
-          .map((m) => `  > [${m.role}] "${normalizeMessageContent(m.content)}..."`)
+          .map((m) => `  > "${JSON.stringify(m, undefined, 2)}"`)
           .join("\n");
         console.log(`[RAG] Received ${chatBody.messages.length} messages:\n${chatHistory}`);
         if (ragEnabled) {

--- a/functions/src/functionImplementations/openai-proxy.ts
+++ b/functions/src/functionImplementations/openai-proxy.ts
@@ -109,9 +109,9 @@ export const chat = onCall(
       let ragContext = "";
       try {
         if (ragEnabled) {
-          let augmentedMessages = [...chatBody.messages];
+          const initialMessageLength = chatBody.messages.length;
           const query =
-            [...augmentedMessages]
+            [...chatBody.messages]
               .reverse()
               .slice(0, 3)
               .map((message) => `[${message.role}]: "${normalizeMessageContent(message.content)}"`)
@@ -129,20 +129,17 @@ export const chat = onCall(
               console.log(
                 `[RAG] Retrieved context length: ${ragContext.length}`,
               );
-              augmentedMessages = injectRAGContext(
-                augmentedMessages,
+              chatBody.messages = injectRAGContext(
+                chatBody.messages,
                 ragContext,
               );
               console.log(
-                `[RAG] Messages count changed from ${chatBody.messages.length} to ${augmentedMessages.length}`,
+                `[RAG] Messages count changed from ${initialMessageLength} to ${chatBody.messages.length}`,
               );
             } else {
               console.log("[RAG] No relevant context found");
             }
           }
-
-          // Update the body with augmented messages
-          chatBody.messages = augmentedMessages;
         }
       } catch (ragError) {
         console.error("[RAG] Error retrieving context:", ragError);

--- a/functions/src/functionImplementations/openai-proxy.ts
+++ b/functions/src/functionImplementations/openai-proxy.ts
@@ -83,7 +83,7 @@ const normalizeMessageContent = (
 
 export const chat = onCall(
   {secrets: [openAIAPIKey], serviceAccount: serviceAccount},
-  async (req, res): Promise<string> => {
+  async (req, res): Promise<string | void> => {
     if (!req.auth?.token) {
       throw new HttpsError("unauthenticated", "User must be authenticated");
     }
@@ -173,7 +173,7 @@ export const chat = onCall(
           await res?.sendChunk(`data: ${JSON.stringify(chunk)}\n\n`);
         }
 
-        return "data: [DONE]\n\n";
+        return;
       }
 
       const response = await openai.chat.completions.create(chatBody);

--- a/functions/src/functionImplementations/openai-proxy.ts
+++ b/functions/src/functionImplementations/openai-proxy.ts
@@ -161,12 +161,12 @@ export const chat = onCall(
             contextLength: ragContext.length,
             enabled: ragEnabled,
           };
-          res?.sendChunk(`data: ${JSON.stringify(ragMetadata)}\n\n`);
+          await res?.sendChunk(`data: ${JSON.stringify(ragMetadata)}\n\n`);
         }
 
         const stream = await openai.chat.completions.create(chatBody);
         for await (const chunk of stream) {
-          res?.sendChunk(`data: ${JSON.stringify(chunk)}\n\n`);
+          await res?.sendChunk(`data: ${JSON.stringify(chunk)}\n\n`);
         }
 
         return "data: [DONE]\n\n";

--- a/functions/src/functionImplementations/openai-proxy.ts
+++ b/functions/src/functionImplementations/openai-proxy.ts
@@ -106,10 +106,10 @@ export const chat = onCall(
       console.log(`[RAG] RAG enabled: ${ragEnabled}`);
 
       // RAG: Retrieve context for the last user message
-      let augmentedMessages = chatBody.messages;
       let ragContext = "";
       try {
         if (ragEnabled) {
+          let augmentedMessages = [...chatBody.messages];
           const query =
             [...augmentedMessages]
               .reverse()
@@ -140,14 +140,14 @@ export const chat = onCall(
               console.log("[RAG] No relevant context found");
             }
           }
+
+          // Update the body with augmented messages
+          chatBody.messages = augmentedMessages;
         }
       } catch (ragError) {
         console.error("[RAG] Error retrieving context:", ragError);
         // Continue without RAG context if there's an error
       }
-
-      // Update the body with augmented messages
-      chatBody.messages = augmentedMessages;
 
       if (chatBody?.stream) {
         // Set streaming headers

--- a/functions/src/functionImplementations/openai-proxy.ts
+++ b/functions/src/functionImplementations/openai-proxy.ts
@@ -105,7 +105,7 @@ export const chat = onCall(
       const ragEnabled = req.rawRequest.query.ragEnabled !== "false";
       console.log(`[RAG] RAG enabled: ${ragEnabled}`);
 
-      const studyId = "spineAI";
+      const studyId = "spineai";
 
       // RAG: Retrieve context for the last user message
       let ragContext = "";

--- a/functions/src/functionImplementations/openai-proxy.ts
+++ b/functions/src/functionImplementations/openai-proxy.ts
@@ -112,7 +112,7 @@ export const chat = onCall(
       try {
         console.log(`[RAG] Received ${chatBody.messages.length} messages`);
         for (const message of chatBody.messages) {
-          console.log(`[RAG, ${message.role}] "${JSON.stringify(message.content)}..."`);
+          console.log(`[RAG, ${message.role}] "${JSON.stringify(message)}..."`);
         }
         console.log(`[RAG] Received ${chatBody.messages.length} messages`);
         if (ragEnabled) {

--- a/functions/src/functionImplementations/openai-proxy.ts
+++ b/functions/src/functionImplementations/openai-proxy.ts
@@ -83,7 +83,7 @@ const normalizeMessageContent = (
 
 export const chat = onCall(
   {secrets: [openAIAPIKey], serviceAccount: serviceAccount},
-  async (req, res) => {
+  async (req, res): Promise<string> => {
     if (!req.auth?.token) {
       throw new HttpsError("unauthenticated", "User must be authenticated");
     }
@@ -111,7 +111,7 @@ export const chat = onCall(
       try {
         if (ragEnabled) {
           const query =
-            [...chatBody.messages]
+            [...augmentedMessages]
               .reverse()
               .slice(0, 3)
               .map((message) => `[${message.role}]: "${normalizeMessageContent(message.content)}"`)
@@ -130,7 +130,7 @@ export const chat = onCall(
                 `[RAG] Retrieved context length: ${ragContext.length}`,
               );
               augmentedMessages = injectRAGContext(
-                chatBody.messages,
+                augmentedMessages,
                 ragContext,
               );
               console.log(
@@ -168,8 +168,7 @@ export const chat = onCall(
           res?.sendChunk(`data: ${JSON.stringify(chunk)}\n\n`);
         }
 
-        res?.sendChunk("data: [DONE]\n\n");
-        return;
+        return "data: [DONE]\n\n";
       }
 
       const response = await openai.chat.completions.create(chatBody);

--- a/functions/src/functionImplementations/openai-proxy.ts
+++ b/functions/src/functionImplementations/openai-proxy.ts
@@ -109,7 +109,7 @@ export const chat = onCall(
       let ragContext = "";
       try {
         const chatHistory = chatBody.messages
-          .map((m) => `  > [${m.role}] "${m.content?.slice(0, 100)}..."`)
+          .map((m) => `  > [${m.role}] "${normalizeMessageContent(m.content)}..."`)
           .join("\n");
         console.log(`[RAG] Received ${chatBody.messages.length} messages:\n${chatHistory}`);
         if (ragEnabled) {

--- a/functions/src/functionImplementations/openai-proxy.ts
+++ b/functions/src/functionImplementations/openai-proxy.ts
@@ -169,6 +169,7 @@ export const chat = onCall(
 
         const stream = await openai.chat.completions.create(chatBody);
         for await (const chunk of stream) {
+          console.log(`[STREAM] Emitting chunk: ${JSON.stringify(chunk)}...`);
           await res?.sendChunk(`data: ${JSON.stringify(chunk)}\n\n`);
         }
 

--- a/functions/src/functionImplementations/openai-proxy.ts
+++ b/functions/src/functionImplementations/openai-proxy.ts
@@ -16,6 +16,7 @@ import type {
 import {retrieveRAGContext} from "../rag/retriever";
 import {serviceAccount} from "../utils/firebase";
 import {openAIAPIKey} from "../utils/genkit";
+import {z} from "genkit";
 
 type ChatBody =
   | ChatCompletionCreateParamsStreaming
@@ -105,6 +106,15 @@ export const chat = onCall(
       const ragEnabled = req.rawRequest.query.ragEnabled !== "false";
       console.log(`[RAG] RAG enabled: ${ragEnabled}`);
 
+      let studyId: string;
+      const defaultStudyId = "edu.stanford.LLMonFHIR.spineAI";
+      try {
+        studyId = z.string().optional().parse(req.rawRequest.query.studyId) ?? defaultStudyId;
+      } catch {
+        console.warn("[RAG]: Falling back to default studyId");
+        studyId = defaultStudyId;
+      }
+
       // RAG: Retrieve context for the last user message
       let ragContext = "";
       try {
@@ -127,7 +137,7 @@ export const chat = onCall(
             );
             ragContext = await retrieveRAGContext({
               query,
-              studyId: "spineai",
+              studyId,
             });
             if (ragContext && ragContext.trim()) {
               console.log(

--- a/functions/src/functionImplementations/openai-proxy.ts
+++ b/functions/src/functionImplementations/openai-proxy.ts
@@ -108,6 +108,10 @@ export const chat = onCall(
       // RAG: Retrieve context for the last user message
       let ragContext = "";
       try {
+        const chatHistory = chatBody.messages
+          .map((m) => `  > [${m.role}] "${m.content?.slice(0, 100)}..."`)
+          .join("\n");
+        console.log(`[RAG] Received ${chatBody.messages.length} messages:\n${chatHistory}`);
         if (ragEnabled) {
           const initialMessageLength = chatBody.messages.length;
           const query =

--- a/functions/src/functionImplementations/openai-proxy.ts
+++ b/functions/src/functionImplementations/openai-proxy.ts
@@ -110,10 +110,11 @@ export const chat = onCall(
       // RAG: Retrieve context for the last user message
       let ragContext = "";
       try {
-        const chatHistory = chatBody.messages
-          .map((m) => `  > "${JSON.stringify(m, undefined, 2)}"`)
-          .join("\n");
-        console.log(`[RAG] Received ${chatBody.messages.length} messages:\n${chatHistory}`);
+        console.log(`[RAG] Received ${chatBody.messages.length} messages`);
+        for (const message of chatBody.messages) {
+          console.log(`[RAG, ${message.role}] "${JSON.stringify(message.content)}..."`);
+        }
+        console.log(`[RAG] Received ${chatBody.messages.length} messages`);
         if (ragEnabled) {
           const initialMessageLength = chatBody.messages.length;
           const query =

--- a/functions/src/functionImplementations/openai-proxy.ts
+++ b/functions/src/functionImplementations/openai-proxy.ts
@@ -82,7 +82,7 @@ const normalizeMessageContent = (
 };
 
 export const chat = onCall(
-  {secrets: [openAIAPIKey], serviceAccount: serviceAccount},
+  {secrets: [openAIAPIKey], serviceAccount: serviceAccount, heartbeatSeconds: null},
   async (req, res): Promise<string | void> => {
     if (!req.auth?.token) {
       throw new HttpsError("unauthenticated", "User must be authenticated");


### PR DESCRIPTION
# Remove nil return value in chat function

## :recycle: Current situation & Problem
The function return value sometimes is nil even though the client expects it to always be a string.

## :gear: Release Notes
- Set chat function return value to be a string.


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Conversations consistently include retrieved contextual info.
  * Streaming reliably signals completion with a final terminator and avoids dropped chunks.

* **Enhancements**
  * Optional RAG metadata is emitted before streaming when enabled.
  * Non-streaming responses return structured payloads (including RAG metadata) for easier client handling.
  * Improved logging of message counts and consistent error behavior across streaming and non-streaming paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->