### PR TITLE
Gemini Support

### DIFF
--- a/functions/src/env.ts
+++ b/functions/src/env.ts
@@ -10,6 +10,7 @@ import {defineSecret} from "firebase-functions/params";
 
 export const Secrets = {
   OPENAI_API_KEY: defineSecret("OPENAI_API_KEY"),
+  GEMINI_API_KEY: defineSecret("GEMINI_API_KEY"),
 };
 
 export const SERVICE_ACCOUNT = `cloud-function-sa@${process.env.GCLOUD_PROJECT}.iam.gserviceaccount.com`;

--- a/functions/src/functions/chat.ts
+++ b/functions/src/functions/chat.ts
@@ -9,21 +9,24 @@
 import {HttpsError, onCall} from "firebase-functions/https";
 import OpenAI from "openai";
 import {Secrets, SERVICE_ACCOUNT} from "../env";
-import {createChatService} from "../services/create-services";
+import {createChatService, LLMService} from "../services/create-services";
 import {ChatBody} from "../services/chat/chat-service";
 
 export const chat = onCall(
-  {secrets: [Secrets.OPENAI_API_KEY], serviceAccount: SERVICE_ACCOUNT},
+  {secrets: [Secrets.OPENAI_API_KEY, Secrets.GEMINI_API_KEY], serviceAccount: SERVICE_ACCOUNT},
   async (req, res): Promise<string | void> => {
     if (!req.auth?.token) {
       throw new HttpsError("unauthenticated", "User must be authenticated");
     }
 
+    const service = (req.rawRequest?.query?.service as LLMService) || "openAI";
     const chatBody = JSON.parse(req.data) as ChatBody;
     try {
       const chatService = createChatService({
         studyId: "spineai",
         openAIApiKey: Secrets.OPENAI_API_KEY.value(),
+        geminiApiKey: Secrets.GEMINI_API_KEY.value(),
+        service,
       });
 
       if (chatBody.stream && req.acceptsStreaming) {

--- a/functions/src/functions/chat.ts
+++ b/functions/src/functions/chat.ts
@@ -9,9 +9,9 @@
 import {HttpsError, onCall} from "firebase-functions/https";
 import OpenAI from "openai";
 import {Secrets, SERVICE_ACCOUNT} from "../env";
-import {createChatService, LLMService} from "../services/create-services";
+import {createChatService} from "../services/create-services";
 import {ChatBody} from "../services/chat/chat-service";
-import { z } from "genkit";
+import {z} from "genkit";
 
 export const chat = onCall(
   {

--- a/functions/src/functions/chat.ts
+++ b/functions/src/functions/chat.ts
@@ -11,6 +11,7 @@ import OpenAI from "openai";
 import {Secrets, SERVICE_ACCOUNT} from "../env";
 import {createChatService, LLMService} from "../services/create-services";
 import {ChatBody} from "../services/chat/chat-service";
+import { z } from "genkit";
 
 export const chat = onCall(
   {
@@ -24,7 +25,7 @@ export const chat = onCall(
       throw new HttpsError("unauthenticated", "User must be authenticated");
     }
 
-    const service = (req.rawRequest?.query?.service as LLMService) || "openAI";
+    const service = z.enum(["gemini", "openAI"]).safeParse(req.rawRequest.query.service).data ?? "openAI";
     const ragEnabled = req.rawRequest.query.ragEnabled === "true";
 
     const studyId = req.rawRequest.query.studyId;

--- a/functions/src/functions/chat.ts
+++ b/functions/src/functions/chat.ts
@@ -13,7 +13,12 @@ import {createChatService, LLMService} from "../services/create-services";
 import {ChatBody} from "../services/chat/chat-service";
 
 export const chat = onCall(
-  {secrets: [Secrets.OPENAI_API_KEY, Secrets.GEMINI_API_KEY], serviceAccount: SERVICE_ACCOUNT, timeoutSeconds: 540, memory: "512MiB"},
+  {
+    secrets: [Secrets.OPENAI_API_KEY, Secrets.GEMINI_API_KEY],
+    serviceAccount: SERVICE_ACCOUNT,
+    timeoutSeconds: 540,
+    memory: "512MiB",
+  },
   async (req, res): Promise<string | void> => {
     if (!req.auth?.token) {
       throw new HttpsError("unauthenticated", "User must be authenticated");

--- a/functions/src/services/chat/agentic-context-chat-interceptor.ts
+++ b/functions/src/services/chat/agentic-context-chat-interceptor.ts
@@ -58,14 +58,10 @@ const RETRIEVE_CONTEXT_TOOL: OpenAI.ChatCompletionTool = {
  * without context.
  */
 export class AgenticContextChatInterceptor implements ChatInterceptor {
-  private readonly openai: OpenAI;
-
   constructor(
-    apiKey: string,
+    private readonly client: OpenAI,
     private readonly contextStore: ContextStore,
-  ) {
-    this.openai = new OpenAI({apiKey});
-  }
+  ) {}
 
   async intercept(body: ChatBody): Promise<ChatBody> {
     try {
@@ -129,7 +125,7 @@ export class AgenticContextChatInterceptor implements ChatInterceptor {
   private async determineQueries(body: ChatBody): Promise<string[]> {
     const messages = this.buildInternalMessages(body.messages);
 
-    const response = await this.openai.chat.completions.create({
+    const response = await this.client.chat.completions.create({
       model: body.model,
       messages,
       tools: [RETRIEVE_CONTEXT_TOOL],

--- a/functions/src/services/chat/chat-service.ts
+++ b/functions/src/services/chat/chat-service.ts
@@ -21,25 +21,27 @@ export type ChatBody =
 /** Callback invoked for each chunk during a streaming response. */
 export type OnChunk = (data: string) => Promise<boolean>;
 
-export class ChatService {
-  private readonly openai: OpenAI;
+export interface ModelOverrides {
+  default: string;
+  [model: string]: string | undefined;
+}
 
+export class ChatService {
   constructor(
-    apiKey: string,
+    private readonly client: OpenAI,
     private readonly interceptors: ChatInterceptor[],
-  ) {
-    this.openai = new OpenAI({apiKey});
-  }
+    private readonly modelOverrides?: ModelOverrides,
+  ) {}
 
   async chatNonStreaming(body: ChatCompletionCreateParamsNonStreaming): Promise<string> {
     const updatedBody = await this.applyInterceptors(body);
-    const response = await this.openai.chat.completions.create(updatedBody as ChatCompletionCreateParamsNonStreaming);
+    const response = await this.client.chat.completions.create(updatedBody as ChatCompletionCreateParamsNonStreaming);
     return JSON.stringify(response);
   }
 
   async chatStreaming(body: ChatCompletionCreateParamsStreaming, onChunk: OnChunk): Promise<void> {
     const updatedBody = await this.applyInterceptors(body);
-    const stream = await this.openai.chat.completions.create(updatedBody as ChatCompletionCreateParamsStreaming);
+    const stream = await this.client.chat.completions.create(updatedBody as ChatCompletionCreateParamsStreaming);
     for await (const chunk of stream) {
       const shouldContinue = await onChunk(`data: ${JSON.stringify(chunk)}\n\n`);
       if (!shouldContinue) {
@@ -51,6 +53,10 @@ export class ChatService {
 
   private async applyInterceptors(body: ChatBody): Promise<ChatBody> {
     let current = body;
+    if (this.modelOverrides) {
+      const mapped = this.modelOverrides[current.model] ?? this.modelOverrides.default;
+      current = {...current, model: mapped};
+    }
     for (const interceptor of this.interceptors) {
       current = await interceptor.intercept(current);
     }

--- a/functions/src/services/create-services.ts
+++ b/functions/src/services/create-services.ts
@@ -8,7 +8,8 @@
 
 import {genkit} from "genkit";
 import openAI from "@genkit-ai/compat-oai/openai";
-import {ChatService} from "./chat/chat-service";
+import OpenAI from "openai";
+import {ChatService, ModelOverrides} from "./chat/chat-service";
 import {RAGChatInterceptor} from "./chat/rag-chat-interceptor";
 import {ComposedChunkingStrategy} from "./chunking/composed-chunking-strategy";
 import {DispatchingTextExtractor} from "./chunking/text-extraction/dispatching-text-extractor";
@@ -21,13 +22,37 @@ import {IndexingService} from "./indexing/indexing-service";
 import {DefaultIndexingService} from "./indexing/default-indexing-service";
 import {SlidingWindowTextChunker} from "./chunking/text-chunking/sliding-window-text-chunker";
 
+export type LLMService = "openAI" | "gemini";
+
+const GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/";
+const GEMINI_MODEL_OVERRIDES: ModelOverrides = {
+  "gpt-4o": "gemini-2.5-flash-preview-05-20",
+  "gpt-4o-mini": "gemini-2.0-flash",
+  default: "gemini-2.0-flash",
+};
+
 export interface ServiceOptions {
   studyId: string;
   openAIApiKey: string;
+  geminiApiKey?: string;
+  service?: LLMService;
 }
 
 function createAI(openAIApiKey: string) {
   return genkit({plugins: [openAI({apiKey: openAIApiKey})]});
+}
+
+function createLLMClient(options: ServiceOptions): { client: OpenAI; modelOverrides?: ModelOverrides } {
+  if (options.service === "gemini") {
+    if (!options.geminiApiKey) {
+      throw new Error("Gemini API key is required when service is 'gemini'");
+    }
+    return {
+      client: new OpenAI({apiKey: options.geminiApiKey, baseURL: GEMINI_BASE_URL}),
+      modelOverrides: GEMINI_MODEL_OVERRIDES,
+    };
+  }
+  return {client: new OpenAI({apiKey: options.openAIApiKey})};
 }
 
 export function createContextStore(studyId: string): ContextStore {
@@ -37,9 +62,11 @@ export function createContextStore(studyId: string): ContextStore {
 export function createChatService(options: ServiceOptions): ChatService {
   const ai = createAI(options.openAIApiKey);
   const contextStore = new FirestoreContextStore(options.studyId, ai);
+  const {client, modelOverrides} = createLLMClient(options);
   return new ChatService(
-    options.openAIApiKey,
+    client,
     [new RAGChatInterceptor(contextStore)],
+    modelOverrides,
   );
 }
 

--- a/functions/src/services/create-services.ts
+++ b/functions/src/services/create-services.ts
@@ -28,7 +28,7 @@ const GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai
 const GEMINI_MODEL_OVERRIDES: ModelOverrides = {
   "gpt-4o": "gemini-2.5-flash-preview-05-20",
   "gpt-4o-mini": "gemini-2.0-flash",
-  default: "gemini-2.0-flash",
+  "default": "gemini-2.0-flash",
 };
 
 export interface ServiceOptions {

--- a/functions/src/services/create-services.ts
+++ b/functions/src/services/create-services.ts
@@ -61,15 +61,15 @@ export function createContextStore(studyId: string): ContextStore {
 }
 
 export function createChatService(options: ServiceOptions): ChatService {
+  const {client, modelOverrides} = createLLMClient(options);
   if (!options.ragEnabled) {
-    return new ChatService(options.openAIApiKey, []);
+    return new ChatService(client, []);
   }
   const ai = createAI(options.openAIApiKey);
   const contextStore = new FirestoreContextStore(options.studyId, ai);
-  const {client, modelOverrides} = createLLMClient(options);
   return new ChatService(
     client,
-    [new AgenticContextChatInterceptor(options.openAIApiKey, contextStore)],
+    [new AgenticContextChatInterceptor(client, contextStore)],
     modelOverrides,
   );
 }

--- a/functions/src/services/create-services.ts
+++ b/functions/src/services/create-services.ts
@@ -26,9 +26,11 @@ export type LLMService = "openAI" | "gemini";
 
 const GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/";
 const GEMINI_MODEL_OVERRIDES: ModelOverrides = {
-  "gpt-4o": "gemini-2.5-flash-preview-05-20",
-  "gpt-4o-mini": "gemini-2.0-flash",
-  "default": "gemini-2.0-flash",
+  "gpt-4o": "gemini-2.5-flash",
+  "gpt-4o-mini": "gemini-2.5-flash-lite",
+  "gpt-5.4": "gemini-3.1-pro-preview",
+  "gpt-5.4-nano": "gemini-3.1-flash-lite-preview",
+  "default": "gemini-3-flash-preview",
 };
 
 export interface ServiceOptions {


### PR DESCRIPTION
# Gemini Support

## :recycle: Current situation & Problem
https://github.com/StanfordBDHG/LLMonFHIR-Firebase/issues/19 mentions that we might want to support more LLM providers, including Gemini. Technically, the following providers could be added by just providing a separate baseURL:

- Gemini (as demonstrated in this PR): [Documentation](https://ai.google.dev/gemini-api/docs/openai)
- Grok
- DeepSeek

Anthropic apparently uses a different API, so we would need to either translate the dtos back-and-forth and/or already change client-code (i.e. in the LLMonFHIR iOS app) to make communication possible.

This change still requires OpenAI access, e.g. for creating embeddings.

## :gear: Release Notes
- Add Gemini as a possible LLM provider besides OpenAI.


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat supports multiple LLM providers: choose between OpenAI and Gemini per request (defaults to OpenAI).
  * You can configure a Gemini API key to enable Gemini-backed chats.
  * Provider-specific model mapping lets the system remap models per provider for consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->