### PR TITLE
Use BulkWriter for multi-write operations

### DIFF
--- a/functions/src/services/context/firestore-context-store.ts
+++ b/functions/src/services/context/firestore-context-store.ts
@@ -61,16 +61,17 @@ export class FirestoreContextStore implements ContextStore {
     console.log(
       `[ContextStore] Storing ${chunks.length} new chunks for ${filename}`,
     );
-    await Promise.all(
-      chunks.map((chunk, index) =>
-        this.firestore.collection(this.collectionName).add({
-          text: chunk.text,
-          embedding: FieldValue.vector(chunk.embedding ?? []),
-          file: filename,
-          chunkId: index,
-        }),
-      ),
+    const bulkWriter = this.firestore.bulkWriter();
+    const collection = this.firestore.collection(this.collectionName);
+    chunks.forEach((chunk, index) =>
+      bulkWriter.create(collection.doc(), {
+        text: chunk.text,
+        embedding: FieldValue.vector(chunk.embedding ?? []),
+        file: filename,
+        chunkId: index,
+      }),
     );
+    await bulkWriter.close();
   }
 
   async delete(filename: string): Promise<void> {
@@ -84,7 +85,9 @@ export class FirestoreContextStore implements ContextStore {
       .where("file", "==", filename)
       .get();
 
-    await Promise.all(snapshot.docs.map((doc) => doc.ref.delete()));
+    const bulkWriter = this.firestore.bulkWriter();
+    snapshot.docs.forEach((doc) => bulkWriter.delete(doc.ref));
+    await bulkWriter.close();
     return snapshot.size;
   }
 }

--- a/functions/src/services/context/firestore-context-store.ts
+++ b/functions/src/services/context/firestore-context-store.ts
@@ -73,16 +73,19 @@ export class FirestoreContextStore implements ContextStore {
       `[ContextStore] Storing ${chunks.length} new chunks for ${filename}`,
     );
     const bulkWriter = this.firestore.bulkWriter();
-    const collection = this.firestore.collection(this.collectionName);
-    chunks.forEach((chunk, index) =>
-      bulkWriter.create(collection.doc(), {
-        text: chunk.text,
-        embedding: FieldValue.vector(chunk.embedding ?? []),
-        file: filename,
-        chunkId: index,
-      }),
-    );
-    await bulkWriter.close();
+    try {
+      const collection = this.firestore.collection(this.collectionName);
+      chunks.forEach((chunk, index) =>
+        bulkWriter.create(collection.doc(), {
+          text: chunk.text,
+          embedding: FieldValue.vector(chunk.embedding ?? []),
+          file: filename,
+          chunkId: index,
+        }),
+      );
+    } finally {
+      await bulkWriter.close();
+    }
   }
 
   async delete(filename: string): Promise<void> {
@@ -97,8 +100,11 @@ export class FirestoreContextStore implements ContextStore {
       .get();
 
     const bulkWriter = this.firestore.bulkWriter();
-    snapshot.docs.forEach((doc) => bulkWriter.delete(doc.ref));
-    await bulkWriter.close();
+    try {
+      snapshot.docs.forEach((doc) => bulkWriter.delete(doc.ref));
+    } finally {
+      await bulkWriter.close();
+    }
     return snapshot.size;
   }
 }


### PR DESCRIPTION
# Use BulkWriter for multi-write operations

## :recycle: Current situation & Problem
In some circumstances, we are unnecessarily doing many write access to Firestore without using BulkWriter.


## :gear: Release Notes
- Use BulkWriter for bulk writing operations.


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized data storage and deletion by switching to batched write operations.
  * Ensures write batches are properly finalized to reduce partial failures.
  * Improves reliability and performance for uploads and cleanup tasks, lowering the chance of inconsistent state and speeding bulk operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->